### PR TITLE
Explain how to sign the linkerd-trust-anchor certificate using Hashicorp Vault

### DIFF
--- a/manifests/cert-manager-root-ca-vault.yaml
+++ b/manifests/cert-manager-root-ca-vault.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: linkerd-vault-issuer
+spec:
+  vault:
+    path: pki/root/sign-intermediate
+    server: http://vault.vault.svc.cluster.local:8200
+    auth:
+      tokenSecretRef:
+          name: vault-token
+          key: token

--- a/manifests/cert-manager-root-ca.yaml
+++ b/manifests/cert-manager-root-ca.yaml
@@ -5,7 +5,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: linkerd-self-signed-issuer
-  namespace: cert-manager
 spec:
   # This ClusterIssuer uses a self-signed certificate.
   selfSigned: {}

--- a/manifests/cert-manager-trust-anchor.yaml
+++ b/manifests/cert-manager-trust-anchor.yaml
@@ -44,7 +44,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: linkerd-trust-anchor
-  namespace: cert-manager
 spec:
   # Rather than just saying "selfSigned", we use the "ca" issuer type to tell
   # cert-manager that this issuer will use a CA certificate stored in a

--- a/manifests/hashicorp-vault.values.yaml
+++ b/manifests/hashicorp-vault.values.yaml
@@ -1,0 +1,26 @@
+global:
+  tlsDisable: true
+
+injector:
+  enabled: false
+
+server:
+  auditStorage:
+    enabled: false
+
+  standalone:
+    enabled: true
+
+  dev:
+    enabled: true
+
+    devRootToken: root-token-1234
+
+  ha:
+    enabled: false
+
+ui:
+  enabled: true
+  serviceType: ClusterIP
+  serviceNodePort: null
+  externalPort: 8200

--- a/manifests/trust-manager-ca-bundle.yaml
+++ b/manifests/trust-manager-ca-bundle.yaml
@@ -7,12 +7,11 @@ apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
   name: linkerd-identity-trust-roots
-  namespace: linkerd
 spec:
   sources:
   - secret:
       name: "linkerd-identity-trust-roots"
-      key: "ca.crt"
+      key: "tls.crt"
   target:
     configMap:
       key: "ca-bundle.crt"


### PR DESCRIPTION
Here's the extension of the demo which shows how you might set up a Root CA in Vault  and a Vault ClusterIssuer,
so that the linkerd-trust-anchor CA is chained to your organisational root CA living outside of the Kubernetes cluster.

/cc @kflynn 
